### PR TITLE
Add MAC computation func for NAS

### DIFF
--- a/src/erlumts_nas_security.erl
+++ b/src/erlumts_nas_security.erl
@@ -5,99 +5,114 @@
          encrypt/7,
          decrypt/6,
          decrypt/7,
-         mac/1,
-         verify_mac/1,
+         mac/6,
+         mac/7,
          kdf/0]).
 
 %% Ciphering
 
-encrypt(Alg, Key, Count, Bearer, Dir, Text) ->
-    encrypt(Alg, Key, Count, Bearer, Dir, Text, bit_size(Text)).
+encrypt(Alg, Key, Count, Bearer, Direction, Text) ->
+    encrypt(Alg, Key, Count, Bearer, Direction, Text, bit_size(Text)).
 
-encrypt(eea1_128, Key, Count, Bearer, Dir, Text, Length) ->
-    encrypt_eea1_128(Key, Count, Bearer, Dir, Text, Length);
-encrypt(eea2_128, Key, Count, Bearer, Dir, Text, Length) ->
-    encrypt_eea2_128(Key, Count, Bearer, Dir, Text, Length);
-encrypt(eea3_128, Key, Count, Bearer, Dir, Text, Length) ->
-    encrypt_eea3_128(Key, Count, Bearer, Dir, Text, Length);
-encrypt(nea1_128, Key, Count, Bearer, Dir, Text, Length) ->
-    encrypt_eea1_128(Key, Count, Bearer, Dir, Text, Length);
-encrypt(nea2_128, Key, Count, Bearer, Dir, Text, Length) ->
-    encrypt_eea2_128(Key, Count, Bearer, Dir, Text, Length);
-encrypt(nea3_128, Key, Count, Bearer, Dir, Text, Length) ->
-    encrypt_eea3_128(Key, Count, Bearer, Dir, Text, Length).
+encrypt(eea1_128, Key, Count, Bearer, Direction, Text, Length) ->
+    encrypt_eea1_128(Key, Count, Bearer, Direction, Text, Length);
+encrypt(eea2_128, Key, Count, Bearer, Direction, Text, Length) ->
+    encrypt_eea2_128(Key, Count, Bearer, Direction, Text, Length);
+encrypt(eea3_128, Key, Count, Bearer, Direction, Text, Length) ->
+    encrypt_eea3_128(Key, Count, Bearer, Direction, Text, Length);
+encrypt(nea1_128, Key, Count, Bearer, Direction, Text, Length) ->
+    encrypt_eea1_128(Key, Count, Bearer, Direction, Text, Length);
+encrypt(nea2_128, Key, Count, Bearer, Direction, Text, Length) ->
+    encrypt_eea2_128(Key, Count, Bearer, Direction, Text, Length);
+encrypt(nea3_128, Key, Count, Bearer, Direction, Text, Length) ->
+    encrypt_eea3_128(Key, Count, Bearer, Direction, Text, Length).
 
-encrypt_eea1_128(_Key, _Count, _Bearer, _Dir, _Text, _Length) ->
+encrypt_eea1_128(_Key, _Count, _Bearer, _Direction, _Text, _Length) ->
     %% 128-EEA1 is based on SNOW 3G and is identical to UEA2 as
     %% specified in TS 35.215. The used IV is constructed the same
     %% way as in subclause 3.4 of that TS.
     unimplemented.
 
-encrypt_eea2_128(Key, Count, Bearer, Dir, Text, Length) ->
-    eea2(Key, Count, Bearer, Dir, Text, Length).
+encrypt_eea2_128(Key, Count, Bearer, Direction, Text, Length) ->
+    eea2(Key, Count, Bearer, Direction, Text, Length).
 
-encrypt_eea3_128(_Key, _Count, _Bearer, _Dir, _Text, _Length) ->
+encrypt_eea3_128(_Key, _Count, _Bearer, _Direction, _Text, _Length) ->
     %% 128-EEA3 is based on ZUC and specified in TS 35.221.
     unimplemented.
 
-decrypt(Alg, Key, Count, Bearer, Dir, Text) ->
-    decrypt(Alg, Key, Count, Bearer, Dir, Text, bit_size(Text)).
+decrypt(Alg, Key, Count, Bearer, Direction, Text) ->
+    decrypt(Alg, Key, Count, Bearer, Direction, Text, bit_size(Text)).
 
-decrypt(eea1_128, Key, Count, Bearer, Dir, Text, Length) ->
-    decrypt_eea1_128(Key, Count, Bearer, Dir, Text, Length);
-decrypt(eea2_128, Key, Count, Bearer, Dir, Text, Length) ->
-    decrypt_eea2_128(Key, Count, Bearer, Dir, Text, Length);
-decrypt(eea3_128, Key, Count, Bearer, Dir, Text, Length) ->
-    decrypt_eea3_128(Key, Count, Bearer, Dir, Text, Length);
-decrypt(nea1_128, Key, Count, Bearer, Dir, Text, Length) ->
-    decrypt_eea1_128(Key, Count, Bearer, Dir, Text, Length);
-decrypt(nea2_128, Key, Count, Bearer, Dir, Text, Length) ->
-    decrypt_eea2_128(Key, Count, Bearer, Dir, Text, Length);
-decrypt(nea3_128, Key, Count, Bearer, Dir, Text, Length) ->
-    decrypt_eea3_128(Key, Count, Bearer, Dir, Text, Length).
+decrypt(eea1_128, Key, Count, Bearer, Direction, Text, Length) ->
+    decrypt_eea1_128(Key, Count, Bearer, Direction, Text, Length);
+decrypt(eea2_128, Key, Count, Bearer, Direction, Text, Length) ->
+    decrypt_eea2_128(Key, Count, Bearer, Direction, Text, Length);
+decrypt(eea3_128, Key, Count, Bearer, Direction, Text, Length) ->
+    decrypt_eea3_128(Key, Count, Bearer, Direction, Text, Length);
+decrypt(nea1_128, Key, Count, Bearer, Direction, Text, Length) ->
+    decrypt_eea1_128(Key, Count, Bearer, Direction, Text, Length);
+decrypt(nea2_128, Key, Count, Bearer, Direction, Text, Length) ->
+    decrypt_eea2_128(Key, Count, Bearer, Direction, Text, Length);
+decrypt(nea3_128, Key, Count, Bearer, Direction, Text, Length) ->
+    decrypt_eea3_128(Key, Count, Bearer, Direction, Text, Length).
 
-decrypt_eea1_128(_Key, _Count, _Bearer, _Dir, _Text, _Length) ->
+decrypt_eea1_128(_Key, _Count, _Bearer, _Direction, _Text, _Length) ->
     %% 128-EEA1 is based on SNOW 3G and is identical to UEA2 as
     %% specified in TS 35.215. The used IV is constructed the same
     %% way as in subclause 3.4 of that TS.
     unimplemented.
 
-decrypt_eea2_128(Key, Count, Bearer, Dir, Text, Length) ->
-    eea2(Key, Count, Bearer, Dir, Text, Length).
+decrypt_eea2_128(Key, Count, Bearer, Direction, Text, Length) ->
+    eea2(Key, Count, Bearer, Direction, Text, Length).
 
-decrypt_eea3_128(_Key, _Count, _Bearer, _Dir, _Text, _Length) ->
+decrypt_eea3_128(_Key, _Count, _Bearer, _Direction, _Text, _Length) ->
     %% 128-EEA3 is based on ZUC and specified in TS 35.221.
     unimplemented.
 
-eea2(Key, Count, Bearer, Dir, Text, Length) ->
+eea2(Key, Count, Bearer, Direction, Text, Length) ->
     %% 128-EEA2 is based on 128-bit AES in CTR mode.
-    X = ((Bearer band 2#11111) bsl 3) bor ((Dir band 2#1) bsl 2),
+    X = ((Bearer band 2#11111) bsl 3) bor ((Direction band 2#1) bsl 2),
     IV = <<Count/binary, <<X>>/binary, 0:88>>,
     Out = crypto:crypto_one_time(aes_128_ctr, Key, IV, Text, true),
     Rest = bit_size(Text) - Length,
     <<O:Length, _:Rest>> = Out,
     <<O:Length, 0:Rest>>.
 
+
 %% Integrity Protection
 
-mac(eia1_128) -> mac_eia1_128();
-mac(eia2_128) -> mac_eia2_128();
-mac(eia3_128) -> mac_eia3_128().
+mac(Alg, Key, Count, Bearer, Direction, Text) ->
+    mac(Alg, Key, Count, Bearer, Direction, Text, bit_size(Text)).
 
-mac_eia1_128() -> unimplemented.
-mac_eia2_128() -> unimplemented.
-mac_eia3_128() -> unimplemented.
+mac(eia1_128, Key, Count, Bearer, Direction, Text, Length) ->
+    mac_eia1_128(Key, Count, Bearer, Direction, Text, Length);
+mac(eia2_128, Key, Count, Bearer, Direction, Text, Length) ->
+    mac_eia2_128(Key, Count, Bearer, Direction, Text, Length);
+mac(eia3_128, Key, Count, Bearer, Direction, Text, Length) ->
+    mac_eia3_128(Key, Count, Bearer, Direction, Text, Length).
 
-verify_mac(eia1) -> verify_eia1_128();
-verify_mac(eia2) -> verify_eia2_128();
-verify_mac(eia3) -> verify_eia3_128();
-verify_mac(nia1) -> verify_eia1_128();
-verify_mac(nia2) -> verify_eia2_128();
-verify_mac(nia3) -> verify_eia3_128().
+mac_eia1_128(_Key, _Count, _Bearer, _Direction, _Text, _Length) ->
+    unimplemented.
+mac_eia2_128(Key, Count, Bearer, Direction, Text, Length) ->
+    eia2(Key, Count, Bearer, Direction, Text, Length).
+mac_eia3_128(_Key, _Count, _Bearer, _Direction, _Text, _Length) ->
+    unimplemented.
 
-verify_eia1_128() -> unimplemented.
-verify_eia2_128() -> unimplemented.
-verify_eia3_128() -> unimplemented.
+eia2(Key, Count, Bearer, Direction, Message, Length) ->
+    %% 128-EIA2 is based on 128-bit AES in CMAC mode.
+    %% NOTE: Message not aligned to 8-bit boundary is not supported.
+    X = ((Bearer band 2#11111) bsl 3) bor ((Direction band 2#1) bsl 2),
+
+    %% TODO: Pad in right way as described in §2.4, RFC 4493
+    %%  In step 4, M_last is calculated by exclusive-OR'ing M_n and one of
+    %%  the previously calculated subkeys.  If the last block is a complete
+    %%  block (true), then M_last is the exclusive-OR of M_n and K1.
+    %%  Otherwise, M_last is the exclusive-OR of padding(M_n) and K2.
+    Rest = bit_size(Message) - Length,
+    <<Msg:Length, _:Rest>> = Message,
+    Input = <<Count/binary, <<X>>/binary, 0:24, <<Msg:Length, 0:Rest>>/binary>>,
+    crypto:macN(cmac, aes_128_cbc, Key, Input, 4).
+
 
 %% Key derivation
 

--- a/src/erlumts_nas_security.erl
+++ b/src/erlumts_nas_security.erl
@@ -72,7 +72,7 @@ decrypt_eea3_128(_Key, _Count, _Bearer, _Direction, _Text, _Length) ->
 eea2(Key, Count, Bearer, Direction, Text, Length) ->
     %% 128-EEA2 is based on 128-bit AES in CTR mode.
     X = ((Bearer band 2#11111) bsl 3) bor ((Direction band 2#1) bsl 2),
-    IV = <<Count/binary, <<X>>/binary, 0:88>>,
+    IV = <<Count/binary, X/integer, 0:88>>,
     Out = crypto:crypto_one_time(aes_128_ctr, Key, IV, Text, true),
     Rest = bit_size(Text) - Length,
     <<O:Length, _:Rest>> = Out,
@@ -81,21 +81,21 @@ eea2(Key, Count, Bearer, Direction, Text, Length) ->
 
 %% Integrity Protection
 
-mac(Alg, Key, Count, Bearer, Direction, Text) ->
-    mac(Alg, Key, Count, Bearer, Direction, Text, bit_size(Text)).
+mac(Alg, Key, Count, Bearer, Direction, Message) ->
+    mac(Alg, Key, Count, Bearer, Direction, Message, bit_size(Message)).
 
-mac(eia1_128, Key, Count, Bearer, Direction, Text, Length) ->
-    mac_eia1_128(Key, Count, Bearer, Direction, Text, Length);
-mac(eia2_128, Key, Count, Bearer, Direction, Text, Length) ->
-    mac_eia2_128(Key, Count, Bearer, Direction, Text, Length);
-mac(eia3_128, Key, Count, Bearer, Direction, Text, Length) ->
-    mac_eia3_128(Key, Count, Bearer, Direction, Text, Length).
+mac(eia1_128, Key, Count, Bearer, Direction, Message, Length) ->
+    mac_eia1_128(Key, Count, Bearer, Direction, Message, Length);
+mac(eia2_128, Key, Count, Bearer, Direction, Message, Length) ->
+    mac_eia2_128(Key, Count, Bearer, Direction, Message, Length);
+mac(eia3_128, Key, Count, Bearer, Direction, Message, Length) ->
+    mac_eia3_128(Key, Count, Bearer, Direction, Message, Length).
 
-mac_eia1_128(_Key, _Count, _Bearer, _Direction, _Text, _Length) ->
+mac_eia1_128(_Key, _Count, _Bearer, _Direction, _Message, _Length) ->
     unimplemented.
-mac_eia2_128(Key, Count, Bearer, Direction, Text, Length) ->
-    eia2(Key, Count, Bearer, Direction, Text, Length).
-mac_eia3_128(_Key, _Count, _Bearer, _Direction, _Text, _Length) ->
+mac_eia2_128(Key, Count, Bearer, Direction, Message, Length) ->
+    eia2(Key, Count, Bearer, Direction, Message, Length).
+mac_eia3_128(_Key, _Count, _Bearer, _Direction, _Message, _Length) ->
     unimplemented.
 
 eia2(Key, Count, Bearer, Direction, Message, Length) ->
@@ -110,7 +110,7 @@ eia2(Key, Count, Bearer, Direction, Message, Length) ->
     %%  Otherwise, M_last is the exclusive-OR of padding(M_n) and K2.
     Rest = bit_size(Message) - Length,
     <<Msg:Length, _:Rest>> = Message,
-    Input = <<Count/binary, <<X>>/binary, 0:24, <<Msg:Length, 0:Rest>>/binary>>,
+    Input = <<Count/binary, X/integer, 0:24, Msg:Length, 0:Rest>>,
     crypto:macN(cmac, aes_128_cbc, Key, Input, 4).
 
 

--- a/test/erlumts_nas_security_tests.erl
+++ b/test/erlumts_nas_security_tests.erl
@@ -217,7 +217,7 @@ mac_tests([TestCase|Rest]) ->
     {Key, Count, Bearer, Direction, Length, Message, MAC} = TestCase,
     Out = erlumts_nas_security:mac(eia2_128, Key, Count, Bearer, Direction, Message, Length),
     ?assertEqual(MAC, Out),
-    encrypt_tests(Rest).
+    mac_tests(Rest).
 
 %% Utilities
 

--- a/test/erlumts_nas_security_tests.erl
+++ b/test/erlumts_nas_security_tests.erl
@@ -3,9 +3,11 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-ts33401_test_sets() ->
+% Ciphering
+
+ts33401_ciphering_test_sets() ->
     %% TS 33.401 C.1.1 - C.1.6
-    %% format: {Key, Count, Bearer, Dir, Length, PlainText, CipherText}
+    %% format: {Key, Count, Bearer, Direction, Length, PlainText, CipherText}
     [{hexstream_to_binary(<<"d3c5d592327fb11c4035c6680af8c6d1">>),
       hexstream_to_binary(<<"398a59b4">>),
       16#15,
@@ -50,26 +52,104 @@ ts33401_test_sets() ->
       hexstream_to_binary(<<"5cb72c6edc878f1566e10253afc364c9fa540d914db94cbee275d0917ca6af0d77acb4ef3bbe1a722b2ef5bd1d4b8e2aa5024ec1388a201e7bce7920aec615895f763a5564dcc4c482a2ee1d8bfecc4498eca83fbb75f9ab530e0dafbede2fa5895b82991b6277c529e0f2529d7f79606be96706296dedfa9d7412b616958cb563c678c02825c30d0aee77c4c146d2765412421a808d13cec819694c75ad572e9b973d948b81a9337c3b2a17192e22c2069f7ed1162af44cdea817603665e807ce40c8e0dd9d6394dc6e31153fe1955c47afb51f2617ee0c5e3b8ef1ad7574ed343edc2743cc94c990e1f1fd264253c178dea739c0befeebcd9f9b76d49c1015c9fecf50e53b8b5204dbcd3eed863855dabcdcc94b31e318021568855c8b9e52a981957a112827f978ba960f1447911b317b5511fbcc7fb13ac153db74251117e4861eb9e83bffffc4eb7755579038e57924b1f78b3e1ad90bab2a07871b72db5eef96c334044966db0c37cafd1a89e5646a3580eb6465f121dce9cb88d85b96cf23ccccd4280767bee8eeb23d8652461db6493103003baf89f5e18261ea43c84a92ebffffe4909dc46c5192f825f770600b9602c557b5f8b431a79d45977dd9c41b863da9e142e90020cfd074d6927b7ab3b6725d1a6f3f98b9c9daa8982aff06782800">>)}].
 
 encrypt_eea2_128_test() ->
-    ok = encrypt_tests(ts33401_test_sets()).
+    ok = encrypt_tests(ts33401_ciphering_test_sets()).
 
 encrypt_tests([]) ->
     ok;
 encrypt_tests([TestCase|Rest]) ->
-    {Key, Count, Bearer, Dir, Length, PlainText, CipherText} = TestCase,
-    Out = erlumts_nas_security:encrypt(eea2_128, Key, Count, Bearer, Dir, PlainText, Length),
+    {Key, Count, Bearer, Direction, Length, PlainText, CipherText} = TestCase,
+    Out = erlumts_nas_security:encrypt(eea2_128, Key, Count, Bearer, Direction, PlainText, Length),
     ?assertEqual(CipherText, Out),
     encrypt_tests(Rest).
 
 decrypt_eea2_128_test() ->
-    ok = decrypt_tests(ts33401_test_sets()).
+    ok = decrypt_tests(ts33401_ciphering_test_sets()).
 
 decrypt_tests([]) ->
     ok;
 decrypt_tests([TestCase|Rest]) ->
-    {Key, Count, Bearer, Dir, Length, PlainText, CipherText} = TestCase,
-    Out = erlumts_nas_security:decrypt(eea2_128, Key, Count, Bearer, Dir, CipherText, Length),
+    {Key, Count, Bearer, Direction, Length, PlainText, CipherText} = TestCase,
+    Out = erlumts_nas_security:decrypt(eea2_128, Key, Count, Bearer, Direction, CipherText, Length),
     ?assertEqual(PlainText, Out),
     decrypt_tests(Rest).
+
+%% Integrity protection
+
+ts33401_integrity_test_sets() ->
+    %% TS 33.401 C.2.1 - C.2.8
+    %% format: {Key, Count, Bearer, Direction, Length, Message, MAC}
+    %% The message in most of the test cases 3GPP provides are not
+    %% aligned to the 8-bit boundary, which we don't currently support.
+    [%{hexstream_to_binary(<<"2bd6459f82c5b300952c49104881ff48">>),
+     % hexstream_to_binary(<<"38a6f056">>),
+     % 16#18,
+     % 0,
+     % 58,
+     % hexstream_to_binary(<<"3332346263393840">>),
+     % hexstream_to_binary(<<"118c6eb8">>)},
+     {hexstream_to_binary(<<"d3c5d592327fb11c4035c6680af8c6d1">>),
+      hexstream_to_binary(<<"398a59b4">>),
+      16#1a,
+      1,
+      64,
+      hexstream_to_binary(<<"484583d5afe082ae">>),
+      hexstream_to_binary(<<"b93787e6">>)}
+     %{hexstream_to_binary(<<"7e5e94431e11d73828d739cc6ced4573">>),
+     % hexstream_to_binary(<<"36af6144">>),
+     % 16#18,
+     % 1,
+     % 254,
+     % hexstream_to_binary(<<"b3d3c9170a4e1632f60f861013d22d84b726b6a278d802d1eeaf1321ba5929dc">>),
+     % hexstream_to_binary(<<"1f60b01d">>)},
+     %{hexstream_to_binary(<<"d3419be821087acd02123a9248033359">>),
+     % hexstream_to_binary(<<"c7590ea9">>),
+     % 16#17,
+     % 0,
+     % 511,
+     % hexstream_to_binary(<<"bbb057038809496bcff86d6fbc8ce5b135a06b166054f2d565be8ace75dc851e0bcdd8f07141c495872fb5d8c0c66a8b6da556663e4e461205d84580bee5bc7e">>),
+     % hexstream_to_binary(<<"6846a2f0">>)},
+     %{hexstream_to_binary(<<"83fd23a244a74cf358da3019f1722635">>),
+     % hexstream_to_binary(<<"36af6144">>),
+     % 16#0f,
+     % 1,
+     % 768,
+     % hexstream_to_binary(<<"35c68716633c66fb750c266865d53c11ea05b1e9fa49c8398d48e1efa5909d3947902837f5ae96d5a05bc8d61ca8dbef1b13a4b4abfe4fb1006045b674bb54729304c382be53a5af05556176f6eaa2ef1d05e4b083181ee674cda5a485f74d7a">>),
+     % hexstream_to_binary(<<"e657e182">>)},
+     %{hexstream_to_binary(<<"d3c5d592327fb11c4035c6680af8c6d1">>),
+     % hexstream_to_binary(<<"36af6144">>),
+     % 16#18,
+     % 0,
+     % 383,
+     % hexstream_to_binary(<<"d3c53839626820717765667620323837636240981ba6824c1bfb1ab485472029b71d808ce33e2cc3c0b5fc1f3de8a6dc">>),
+     % hexstream_to_binary(<<"f0668c1e">>)},
+     %{hexstream_to_binary(<<"5d0a80d8134ae19677824b671e838af4 ">>),
+     % hexstream_to_binary(<<"7827fab2">>),
+     % 16#05,
+     % 1,
+     % 2558,
+     % hexstream_to_binary(<<"70dedf2dc42c5cbd3a96f8a0b11418b3608d5733604a2cd36aabc70ce3193bb5153be2d3c06dfdb2d16e9c357158be6a41d6b861e491db3fbfeb518efcf048d7d58953730ff30c9ec470ffcd663dc34201c36addc0111c35b38afee7cfdb582e3731f8b4baa8d1a89c06e81199a9716227be344efcb436ddd0f096c064c3b5e2c399993fc77394f9e09720a811850ef23b2ee05d9e6173609d86e1c0c18ea51a012a00bb413b9cb8188a703cd6bae31cc67b34b1b00019e6a2b2a690f02671fe7c9ef8dec0094e533763478d58d2c5f5b827a0148c5948a96931acf84f465a64e62ce74007e991e37ea823fa0fb21923b79905b733b631e6c7d6860a3831ac351a9c730c52ff72d9d308eedbab21fde143a0ea17e23edc1f74cbb3638a2033aaa15464eaa733385dbbeb6fd73509b857e6a419dca1d8907af977fbac4dfa35ec">>),
+     % hexstream_to_binary(<<"f4cc8fa3">>)},
+     %{hexstream_to_binary(<<"b3120ffdb2cf6af4e73eaf2ef4ebec69">>),
+     % hexstream_to_binary(<<"296f393c">>),
+     % 16#0b,
+     % 1,
+     % 16448,
+     % hexstream_to_binary(<<"00000000000000000101010101010101e0958045f3a0bba4e3968346f0a3b8a7c02a018ae640765226b987c913e6cbf083570016cf83efbc61c082513e21561a427c009d28c298eface78ed6d56c2d4505ad032e9c04dc60e73a81696da665c6c48603a57b45ab33221585e68ee3169187fb0239528632dd656c807ea3248b7b46d002b2b5c7458eb85b9ce95879e0340859055e3b0abbc3eace8719caa80265c97205d5dc4bcc902fe1839629ed71328a0f0449f588557e6898860e042aecd84b2404c212c9222da5bf8a89ef6797870cf50771a60f66a2ee62853657addf04cdde07fa414e11f12b4d81b9b4e8ac538ea30666688d881f6c348421992f31b94f8806ed8fccff4c9123b89642527ad613b109bf75167485f1268bf884b4cd23d29a0934925703d634098f7767f1be7491e708a8bb949a3873708aef4a36239e50cc08235cd5ed6bbe578668a17b58c1171d0b90e813a9e4f58a89d719b11042d6360b1b0f52deb730a58d58faf46315954b0a872691475977dc88c0d733feff54600a0cc1d0300aaaeb94572c6e95b01ae90de04f1dce47f87e8fa7bebf77e1dbc20d6ba85cb9143d518b285dfa04b698bf0cf7819f20fa7a288eb0703d995c59940c7c66de57a9b70f82379b70e2031e450fcfd2181326fcd28d8823baaa80df6e0f443559647539fd8907c0ffd9d79c130ed81c9afd9b7e848c9fed38443d5d380e53fbdb8ac8c3d3f06876054f122461107de92fea09c6f6923a188d53afe54a10f60e6e9d5a03d996b5fbc820f8a637116a27ad04b444a0932dd60fbd12671c11e1c0ec73e789879faa3d42c64d20cd1252742a3768c25a901585888ecee1e612d9936b403b0775949a66cdfd99a29b1345baa8d9d5400c91024b0a607363b013ce5de9ae869d3b8d95b0570b3c2d391422d32450cbcfae96652286e96dec1214a9346527980a8192eac1c39a3aaf6f15351da6be764df89772ec0407d06e4415befae7c92580df9bf507497c8f2995160d4e218daacb02944abf83340ce8be1686a960faf90e2d90c55cc6475babc3171a80a363174954955d7101dab16ae8179167e21444b443a9eaaa7c91de36d118c39d389f8dd4469a846c9a262bf7fa18487a79e8de11699e0b8fdf557cb48719d453ba713056109b93a218c89675ac195fb4fb06639b3797144955b3c9327d1aec003d42ecd0ea98abf19ffb4af3561a67e77c35bf15c59c2412da881db02b1bfbcebfac5152bc99bc3f1d15f771001b7029fedb028f8b852bc4407eb83f891c9ca733254fdd1e9edb56919ce9fea21c174072521c18319a54b5d4efbebddf1d8b69b1cbf25f489fcc981372547cf41d008ef0bca1926f934b735e090b3b251eb33a36f82ed9b29cf4cb944188fa0e1e38dd778f7d1c9d987b28d132dfb9731fa4f4b416935be49de30516af3578581f2f13f561c0663361941eab249a4bc123f8d15cd711a956a1bf20fe6eb78aea2373361da0426c79a530c3bb1de0c99722ef1fde39ac2b00a0a8ee7c800a08bc2264f89f4effe627ac2f0531fb554f6d21d74c590a70adfaa390bdfbb3d68e46215cab187d2368d5a71f5ebec081cd3b20c082dbe4cd2faca28773795d6b0c10204b659a939ef29bbe1088243624429927a7eb576dd3a00ea5e01af5d47583b2272c0c161a806521a16ff9b0a722c0cf26b025d5836e2258a4f7d4773ac801e4263bc294f43def7fa8703f3a4197463525887652b0b2a4a2a7cf87f00914871e25039113c7e1618da34064b57a43c463249fb8d05e0f26f4a6d84972e7a9054824145f91295cdbe39a6f920facc659712b46a54ba295bbe6a90154e91b33985a2bcd420ad5c67ec9ad8eb7ac6864db272a516bc94c2839b0a8169a6bf58e1a0c2ada8c883b7bf497a49171268ed15ddd2969384e7ff4bf4aab2ec9ecc6529cf629e2df0f08a77a65afa12aa9b505df8b287ef6cc91493d1caa39076e28ef1ea028f5118de61ae02bb6aefc3343a050292f199f401857b2bead5e6ee2a1f191022f9278016f047791a9d18da7d2a6d27f2e0e51c2f6ea30e8ac49a0604f4c13542e85b68381b9fdcfa0ce4b2d341354852d360245c536b612af71f3e77c9095ae2dbde504b265733dabfe10a20fc7d6d32c21ccc72b8b3444ae663d65922d17f82caa2b865cd88913d291a65899026ea1328439723c198c36b0c3c8d085bfaf8a320fde334b4a4919b44c2b95f6e8ecf73393f7f0d2a40e60b1d406526b022ddc331810b1a5f7c347bd53ed1f105d6a0d30aba477e178889ab2ec55d558deab2630204336962b4db5b663b6902b89e85b31bc6af50fc50accb3fb9b57b663297031378db47896d7fbaf6c600add2c67f936db037986db856eb49cf2db3f7da6d23650e438f1884041b013119e4c2ae5af37cccdfb68660738b58b3c59d1c0248437472aba1f35ca1fb90cd714aa9f635534f49e7c5bba81c2b6b36fdee21ca27e347f793d2ce944edb23c8c9b914be10335e350feb5070394b7a4a15c0ca120283568b7bfc254fe838b137a2147ce7c113a3a4d65499d9e86b87dbcc7f03bbd3a3ab1aa243ece5ba9bcf25f82836cfe473b2d83e7a7201cd0b96a72451e863f6c3ba664a6d073d1f7b5ed990865d978bd3815d06094fc9a2aba5221c22d5ab996389e3721e3af5f05beddc2875e0dfaeb39021ee27a41187cbb45ef40c3e73bc03989f9a30d12c54ba7d2141da8a875493e65776ef35f97debc2286cc4af9b4623eee902f840c52f1b8ad658939aef71f3f72b9ec1de21588bd35484ea44436343ff95ead6ab1d8afb1b2a303df1b71e53c4aea6b2e3e9372be0d1bc99798b0ce3cc10d2a596d565dba82f88ce4cff3b33d5d24e9c0831124bf1ad54b792532983dd6c3a8b7d0">>),
+     % hexstream_to_binary(<<"ebd5ccb0">>)}
+    ].
+
+mac_eia2_128_test() ->
+    mac_tests(ts33401_integrity_test_sets()).
+
+mac_tests([]) ->
+    ok;
+mac_tests([TestCase|Rest]) ->
+    {Key, Count, Bearer, Direction, Length, Message, MAC} = TestCase,
+    Out = erlumts_nas_security:mac(eia2_128, Key, Count, Bearer, Direction, Message, Length),
+    ?assertEqual(MAC, Out),
+    encrypt_tests(Rest).
+
+%% Utilities
 
 hexstream_to_binary(In) ->
     list_to_binary([binary_to_integer(<<A, B>>, 16) || <<A, B>> <= In]).

--- a/test/erlumts_nas_security_tests.erl
+++ b/test/erlumts_nas_security_tests.erl
@@ -13,43 +13,153 @@ ts33401_ciphering_test_sets() ->
       16#15,
       1,
       253,
-      hexstream_to_binary(<<"981ba6824c1bfb1ab485472029b71d808ce33e2cc3c0b5fc1f3de8a6dc66b1f0">>),
-      hexstream_to_binary(<<"e9fed8a63d155304d71df20bf3e82214b20ed7dad2f233dc3c22d7bdeeed8e78">>)},
+      hexstream_to_binary(<<"981ba6824c1bfb1ab485472029b71d80"
+                            "8ce33e2cc3c0b5fc1f3de8a6dc66b1f0">>),
+      hexstream_to_binary(<<"e9fed8a63d155304d71df20bf3e82214"
+                            "b20ed7dad2f233dc3c22d7bdeeed8e78">>)},
      {hexstream_to_binary(<<"2bd6459f82c440e0952c49104805ff48">>),
       hexstream_to_binary(<<"c675a64b">>),
       16#0c,
       1,
       798,
-      hexstream_to_binary(<<"7ec61272743bf1614726446a6c38ced166f6ca76eb5430044286346cef130f92922b03450d3a9975e5bd2ea0eb55ad8e1b199e3ec4316020e9a1b285e762795359b7bdfd39bef4b2484583d5afe082aee638bf5fd5a606193901a08f4ab41aab9b134880">>),
-      hexstream_to_binary(<<"5961605353c64bdca15b195e288553a910632506d6200aa790c4c806c99904cf2445cc50bb1cf168a49673734e081b57e324ce5259c0e78d4cd97b870976503c0943f2cb5ae8f052c7b7d392239587b8956086bcab18836042e2e6ce42432a17105c53d0">>)},
+      hexstream_to_binary(<<"7ec61272743bf1614726446a6c38ced1"
+                            "66f6ca76eb5430044286346cef130f92"
+                            "922b03450d3a9975e5bd2ea0eb55ad8e"
+                            "1b199e3ec4316020e9a1b285e7627953"
+                            "59b7bdfd39bef4b2484583d5afe082ae"
+                            "e638bf5fd5a606193901a08f4ab41aab"
+                            "9b134880">>),
+      hexstream_to_binary(<<"5961605353c64bdca15b195e288553a9"
+                            "10632506d6200aa790c4c806c99904cf"
+                            "2445cc50bb1cf168a49673734e081b57"
+                            "e324ce5259c0e78d4cd97b870976503c"
+                            "0943f2cb5ae8f052c7b7d392239587b8"
+                            "956086bcab18836042e2e6ce42432a17"
+                            "105c53d0">>)},
      {hexstream_to_binary(<<"0a8b6bd8d9b08b08d64e32d1817777fb">>),
       hexstream_to_binary(<<"544d49cd">>),
       16#04,
       0,
       310,
-      hexstream_to_binary(<<"fd40a41d370a1f65745095687d47ba1d36d2349e23f644392c8ea9c49d40c13271aff264d0f24800">>),
-      hexstream_to_binary(<<"75750d37b4bba2a4dedb34235bd68c6645acdaaca48138a3b0c471e2a7041a576423d2927287f000">>)},
+      hexstream_to_binary(<<"fd40a41d370a1f65745095687d47ba1d"
+                            "36d2349e23f644392c8ea9c49d40c132"
+                            "71aff264d0f24800">>),
+      hexstream_to_binary(<<"75750d37b4bba2a4dedb34235bd68c66"
+                            "45acdaaca48138a3b0c471e2a7041a57"
+                            "6423d2927287f000">>)},
      {hexstream_to_binary(<<"aa1f95aea533bcb32eb63bf52d8f831a">>),
       hexstream_to_binary(<<"72d8c671">>),
       16#10,
       1,
       1022,
-      hexstream_to_binary(<<"fb1b96c5c8badfb2e8e8edfde78e57f2ad81e74103fc430a534dcc37afcec70e1517bb06f27219dae49022ddc47a068de4c9496a951a6b09edbdc864c7adbd740ac50c022f3082bafd22d78197c5d508b977bca13f32e652e74ba728576077ce628c535e87dc6077ba07d29068590c8cb5f1088e082cfa0ec961302d69cf3d44">>),
-      hexstream_to_binary(<<"dfb440acb3773549efc04628aeb8d8156275230bdc690d94b00d8d95f28c4b56307f60f4ca55eba661ebba72ac808fa8c49e26788ed04a5d606cb418de74878b9a22f8ef29590bc4eb57c9faf7c41524a885b8979c423f2f8f8e0592a9879201be7ff9777a162ab810feb324ba74c4c156e04d39097209653ac33e5a5f2d8864">>)},
+      hexstream_to_binary(<<"fb1b96c5c8badfb2e8e8edfde78e57f2"
+                            "ad81e74103fc430a534dcc37afcec70e"
+                            "1517bb06f27219dae49022ddc47a068d"
+                            "e4c9496a951a6b09edbdc864c7adbd74"
+                            "0ac50c022f3082bafd22d78197c5d508"
+                            "b977bca13f32e652e74ba728576077ce"
+                            "628c535e87dc6077ba07d29068590c8c"
+                            "b5f1088e082cfa0ec961302d69cf3d44">>),
+      hexstream_to_binary(<<"dfb440acb3773549efc04628aeb8d815"
+                            "6275230bdc690d94b00d8d95f28c4b56"
+                            "307f60f4ca55eba661ebba72ac808fa8"
+                            "c49e26788ed04a5d606cb418de74878b"
+                            "9a22f8ef29590bc4eb57c9faf7c41524"
+                            "a885b8979c423f2f8f8e0592a9879201"
+                            "be7ff9777a162ab810feb324ba74c4c1"
+                            "56e04d39097209653ac33e5a5f2d8864">>)},
      {hexstream_to_binary(<<"9618ae46891f86578eebe90ef7a1202e">>),
       hexstream_to_binary(<<"c675a64b">>),
       16#0c,
       1,
       1245,
-      hexstream_to_binary(<<"8daa17b1ae050529c6827f28c0ef6a1242e93f8b314fb18a77f790ae049fedd612267fecaefc450174d76d9f9aa7755a30cd90a9a5874bf48eaf70eea3a62a250a8b6bd8d9b08b08d64e32d1817777fb544d49cd49720e219dbf8bbed33904e1fd40a41d370a1f65745095687d47ba1d36d2349e23f644392c8ea9c49d40c13271aff264d0f24841d6465f0996ff84e65fc517c53efc3363c38492a8">>),
-      hexstream_to_binary(<<"919c8c33d66789703d05a0d7ce82a2aeac4ee76c0f4da050335e8a84e7897ba5df2f36bd513e3d0c8578c7a0fcf043e03aa3a39fbaad7d15be074faa5d9029f71fb457b647834714b0e18f117fca10677945096c8c5f326ba8d6095eb29c3e36cf245d1622aafe921f7566c4f5d644f2f1fc0ec684ddb21349747622e209295d27ff3f95623371d49b147c0af486171f22cd04b1cbeb2658223e6938">>)},
+      hexstream_to_binary(<<"8daa17b1ae050529c6827f28c0ef6a12"
+                            "42e93f8b314fb18a77f790ae049fedd6"
+                            "12267fecaefc450174d76d9f9aa7755a"
+                            "30cd90a9a5874bf48eaf70eea3a62a25"
+                            "0a8b6bd8d9b08b08d64e32d1817777fb"
+                            "544d49cd49720e219dbf8bbed33904e1"
+                            "fd40a41d370a1f65745095687d47ba1d"
+                            "36d2349e23f644392c8ea9c49d40c132"
+                            "71aff264d0f24841d6465f0996ff84e6"
+                            "5fc517c53efc3363c38492a8">>),
+      hexstream_to_binary(<<"919c8c33d66789703d05a0d7ce82a2ae"
+                            "ac4ee76c0f4da050335e8a84e7897ba5"
+                            "df2f36bd513e3d0c8578c7a0fcf043e0"
+                            "3aa3a39fbaad7d15be074faa5d9029f7"
+                            "1fb457b647834714b0e18f117fca1067"
+                            "7945096c8c5f326ba8d6095eb29c3e36"
+                            "cf245d1622aafe921f7566c4f5d644f2"
+                            "f1fc0ec684ddb21349747622e209295d"
+                            "27ff3f95623371d49b147c0af486171f"
+                            "22cd04b1cbeb2658223e6938">>)},
      {hexstream_to_binary(<<"54f4e2e04c83786eec8fb5abe8e36566">>),
       hexstream_to_binary(<<"aca4f50f">>),
       16#0b,
       0,
       3861,
-      hexstream_to_binary(<<"40981ba6824c1bfb4286b299783daf442c099f7ab0f58d5c8e46b104f08f01b41ab485472029b71d36bd1a3d90dc3a41b46d51672ac4c9663a2be063da4bc8d2808ce33e2cccbfc634e1b259060876a0fbb5a437ebcc8d31c19e4454318745e3fa16bb11adae248879fe52db2543e53cf445d3d828ce0bf5c560593d97278a59762dd0c2c9cd68d4496a792508614014b13b6aa51128c18cd6a90b87978c2ff1cabe7d9f898a411bfdb84f68f6727b1499cdd30df0443ab4a66653330bcba1105e4cec034c73e605b4310eaaadcfd5b0ca27ffd89d144df4792759427c9cc1f8cd8c87202364b8a687954cb05a8d4e2d99e73db160deb180ad0841e96741a5d59fe4189f15420026fe4cd12104932fb38f735340438aaf7eca6fd5cfd3a195ce5abe65272af607ada1be65a6b4c9c0693234092c4d018f1756c6db9dc8a6d80b888138616b681262f954d0e7711748780d92291d86299972db741cfa4f37b8b56cdb18a7ca8218e86e4b4b716a4d04371fbec262fc5ad0b3819b187b97e55b1a4d7c19ee24c8b4d7723cfedf045b8acae4869517d80e50615d9035d5d9c5a40af602280b542597b0cb18619eeb35925759d195e100e8e4aa0c38a3c2abe0f3d8ff04f3c33c295069c23694b5bbeacdd542e28e8a94edb9119f412d054be1fa7200b09000">>),
-      hexstream_to_binary(<<"5cb72c6edc878f1566e10253afc364c9fa540d914db94cbee275d0917ca6af0d77acb4ef3bbe1a722b2ef5bd1d4b8e2aa5024ec1388a201e7bce7920aec615895f763a5564dcc4c482a2ee1d8bfecc4498eca83fbb75f9ab530e0dafbede2fa5895b82991b6277c529e0f2529d7f79606be96706296dedfa9d7412b616958cb563c678c02825c30d0aee77c4c146d2765412421a808d13cec819694c75ad572e9b973d948b81a9337c3b2a17192e22c2069f7ed1162af44cdea817603665e807ce40c8e0dd9d6394dc6e31153fe1955c47afb51f2617ee0c5e3b8ef1ad7574ed343edc2743cc94c990e1f1fd264253c178dea739c0befeebcd9f9b76d49c1015c9fecf50e53b8b5204dbcd3eed863855dabcdcc94b31e318021568855c8b9e52a981957a112827f978ba960f1447911b317b5511fbcc7fb13ac153db74251117e4861eb9e83bffffc4eb7755579038e57924b1f78b3e1ad90bab2a07871b72db5eef96c334044966db0c37cafd1a89e5646a3580eb6465f121dce9cb88d85b96cf23ccccd4280767bee8eeb23d8652461db6493103003baf89f5e18261ea43c84a92ebffffe4909dc46c5192f825f770600b9602c557b5f8b431a79d45977dd9c41b863da9e142e90020cfd074d6927b7ab3b6725d1a6f3f98b9c9daa8982aff06782800">>)}].
+      hexstream_to_binary(<<"40981ba6824c1bfb4286b299783daf44"
+                            "2c099f7ab0f58d5c8e46b104f08f01b4"
+                            "1ab485472029b71d36bd1a3d90dc3a41"
+                            "b46d51672ac4c9663a2be063da4bc8d2"
+                            "808ce33e2cccbfc634e1b259060876a0"
+                            "fbb5a437ebcc8d31c19e4454318745e3"
+                            "fa16bb11adae248879fe52db2543e53c"
+                            "f445d3d828ce0bf5c560593d97278a59"
+                            "762dd0c2c9cd68d4496a792508614014"
+                            "b13b6aa51128c18cd6a90b87978c2ff1"
+                            "cabe7d9f898a411bfdb84f68f6727b14"
+                            "99cdd30df0443ab4a66653330bcba110"
+                            "5e4cec034c73e605b4310eaaadcfd5b0"
+                            "ca27ffd89d144df4792759427c9cc1f8"
+                            "cd8c87202364b8a687954cb05a8d4e2d"
+                            "99e73db160deb180ad0841e96741a5d5"
+                            "9fe4189f15420026fe4cd12104932fb3"
+                            "8f735340438aaf7eca6fd5cfd3a195ce"
+                            "5abe65272af607ada1be65a6b4c9c069"
+                            "3234092c4d018f1756c6db9dc8a6d80b"
+                            "888138616b681262f954d0e771174878"
+                            "0d92291d86299972db741cfa4f37b8b5"
+                            "6cdb18a7ca8218e86e4b4b716a4d0437"
+                            "1fbec262fc5ad0b3819b187b97e55b1a"
+                            "4d7c19ee24c8b4d7723cfedf045b8aca"
+                            "e4869517d80e50615d9035d5d9c5a40a"
+                            "f602280b542597b0cb18619eeb359257"
+                            "59d195e100e8e4aa0c38a3c2abe0f3d8"
+                            "ff04f3c33c295069c23694b5bbeacdd5"
+                            "42e28e8a94edb9119f412d054be1fa72"
+                            "00b09000">>),
+      hexstream_to_binary(<<"5cb72c6edc878f1566e10253afc364c9"
+                            "fa540d914db94cbee275d0917ca6af0d"
+                            "77acb4ef3bbe1a722b2ef5bd1d4b8e2a"
+                            "a5024ec1388a201e7bce7920aec61589"
+                            "5f763a5564dcc4c482a2ee1d8bfecc44"
+                            "98eca83fbb75f9ab530e0dafbede2fa5"
+                            "895b82991b6277c529e0f2529d7f7960"
+                            "6be96706296dedfa9d7412b616958cb5"
+                            "63c678c02825c30d0aee77c4c146d276"
+                            "5412421a808d13cec819694c75ad572e"
+                            "9b973d948b81a9337c3b2a17192e22c2"
+                            "069f7ed1162af44cdea817603665e807"
+                            "ce40c8e0dd9d6394dc6e31153fe1955c"
+                            "47afb51f2617ee0c5e3b8ef1ad7574ed"
+                            "343edc2743cc94c990e1f1fd264253c1"
+                            "78dea739c0befeebcd9f9b76d49c1015"
+                            "c9fecf50e53b8b5204dbcd3eed863855"
+                            "dabcdcc94b31e318021568855c8b9e52"
+                            "a981957a112827f978ba960f1447911b"
+                            "317b5511fbcc7fb13ac153db74251117"
+                            "e4861eb9e83bffffc4eb7755579038e5"
+                            "7924b1f78b3e1ad90bab2a07871b72db"
+                            "5eef96c334044966db0c37cafd1a89e5"
+                            "646a3580eb6465f121dce9cb88d85b96"
+                            "cf23ccccd4280767bee8eeb23d865246"
+                            "1db6493103003baf89f5e18261ea43c8"
+                            "4a92ebffffe4909dc46c5192f825f770"
+                            "600b9602c557b5f8b431a79d45977dd9"
+                            "c41b863da9e142e90020cfd074d6927b"
+                            "7ab3b6725d1a6f3f98b9c9daa8982aff"
+                            "06782800">>)}].
 
 encrypt_eea2_128_test() ->
     ok = encrypt_tests(ts33401_ciphering_test_sets()).
@@ -78,15 +188,11 @@ decrypt_tests([TestCase|Rest]) ->
 ts33401_integrity_test_sets() ->
     %% TS 33.401 C.2.1 - C.2.8
     %% format: {Key, Count, Bearer, Direction, Length, Message, MAC}
-    %% The message in most of the test cases 3GPP provides are not
-    %% aligned to the 8-bit boundary, which we don't currently support.
-    [%{hexstream_to_binary(<<"2bd6459f82c5b300952c49104881ff48">>),
-     % hexstream_to_binary(<<"38a6f056">>),
-     % 16#18,
-     % 0,
-     % 58,
-     % hexstream_to_binary(<<"3332346263393840">>),
-     % hexstream_to_binary(<<"118c6eb8">>)},
+    %% NOTE: We don't support the MAC computation of the messages
+    %% that are not aligned to the 8-bit boundary, so most of the
+    %% test cases 3GPP provides are not tested here at this moment.
+    [%% C.2.1 - not supported yet
+     %% C.2.2
      {hexstream_to_binary(<<"d3c5d592327fb11c4035c6680af8c6d1">>),
       hexstream_to_binary(<<"398a59b4">>),
       16#1a,
@@ -94,48 +200,12 @@ ts33401_integrity_test_sets() ->
       64,
       hexstream_to_binary(<<"484583d5afe082ae">>),
       hexstream_to_binary(<<"b93787e6">>)}
-     %{hexstream_to_binary(<<"7e5e94431e11d73828d739cc6ced4573">>),
-     % hexstream_to_binary(<<"36af6144">>),
-     % 16#18,
-     % 1,
-     % 254,
-     % hexstream_to_binary(<<"b3d3c9170a4e1632f60f861013d22d84b726b6a278d802d1eeaf1321ba5929dc">>),
-     % hexstream_to_binary(<<"1f60b01d">>)},
-     %{hexstream_to_binary(<<"d3419be821087acd02123a9248033359">>),
-     % hexstream_to_binary(<<"c7590ea9">>),
-     % 16#17,
-     % 0,
-     % 511,
-     % hexstream_to_binary(<<"bbb057038809496bcff86d6fbc8ce5b135a06b166054f2d565be8ace75dc851e0bcdd8f07141c495872fb5d8c0c66a8b6da556663e4e461205d84580bee5bc7e">>),
-     % hexstream_to_binary(<<"6846a2f0">>)},
-     %{hexstream_to_binary(<<"83fd23a244a74cf358da3019f1722635">>),
-     % hexstream_to_binary(<<"36af6144">>),
-     % 16#0f,
-     % 1,
-     % 768,
-     % hexstream_to_binary(<<"35c68716633c66fb750c266865d53c11ea05b1e9fa49c8398d48e1efa5909d3947902837f5ae96d5a05bc8d61ca8dbef1b13a4b4abfe4fb1006045b674bb54729304c382be53a5af05556176f6eaa2ef1d05e4b083181ee674cda5a485f74d7a">>),
-     % hexstream_to_binary(<<"e657e182">>)},
-     %{hexstream_to_binary(<<"d3c5d592327fb11c4035c6680af8c6d1">>),
-     % hexstream_to_binary(<<"36af6144">>),
-     % 16#18,
-     % 0,
-     % 383,
-     % hexstream_to_binary(<<"d3c53839626820717765667620323837636240981ba6824c1bfb1ab485472029b71d808ce33e2cc3c0b5fc1f3de8a6dc">>),
-     % hexstream_to_binary(<<"f0668c1e">>)},
-     %{hexstream_to_binary(<<"5d0a80d8134ae19677824b671e838af4 ">>),
-     % hexstream_to_binary(<<"7827fab2">>),
-     % 16#05,
-     % 1,
-     % 2558,
-     % hexstream_to_binary(<<"70dedf2dc42c5cbd3a96f8a0b11418b3608d5733604a2cd36aabc70ce3193bb5153be2d3c06dfdb2d16e9c357158be6a41d6b861e491db3fbfeb518efcf048d7d58953730ff30c9ec470ffcd663dc34201c36addc0111c35b38afee7cfdb582e3731f8b4baa8d1a89c06e81199a9716227be344efcb436ddd0f096c064c3b5e2c399993fc77394f9e09720a811850ef23b2ee05d9e6173609d86e1c0c18ea51a012a00bb413b9cb8188a703cd6bae31cc67b34b1b00019e6a2b2a690f02671fe7c9ef8dec0094e533763478d58d2c5f5b827a0148c5948a96931acf84f465a64e62ce74007e991e37ea823fa0fb21923b79905b733b631e6c7d6860a3831ac351a9c730c52ff72d9d308eedbab21fde143a0ea17e23edc1f74cbb3638a2033aaa15464eaa733385dbbeb6fd73509b857e6a419dca1d8907af977fbac4dfa35ec">>),
-     % hexstream_to_binary(<<"f4cc8fa3">>)},
-     %{hexstream_to_binary(<<"b3120ffdb2cf6af4e73eaf2ef4ebec69">>),
-     % hexstream_to_binary(<<"296f393c">>),
-     % 16#0b,
-     % 1,
-     % 16448,
-     % hexstream_to_binary(<<"00000000000000000101010101010101e0958045f3a0bba4e3968346f0a3b8a7c02a018ae640765226b987c913e6cbf083570016cf83efbc61c082513e21561a427c009d28c298eface78ed6d56c2d4505ad032e9c04dc60e73a81696da665c6c48603a57b45ab33221585e68ee3169187fb0239528632dd656c807ea3248b7b46d002b2b5c7458eb85b9ce95879e0340859055e3b0abbc3eace8719caa80265c97205d5dc4bcc902fe1839629ed71328a0f0449f588557e6898860e042aecd84b2404c212c9222da5bf8a89ef6797870cf50771a60f66a2ee62853657addf04cdde07fa414e11f12b4d81b9b4e8ac538ea30666688d881f6c348421992f31b94f8806ed8fccff4c9123b89642527ad613b109bf75167485f1268bf884b4cd23d29a0934925703d634098f7767f1be7491e708a8bb949a3873708aef4a36239e50cc08235cd5ed6bbe578668a17b58c1171d0b90e813a9e4f58a89d719b11042d6360b1b0f52deb730a58d58faf46315954b0a872691475977dc88c0d733feff54600a0cc1d0300aaaeb94572c6e95b01ae90de04f1dce47f87e8fa7bebf77e1dbc20d6ba85cb9143d518b285dfa04b698bf0cf7819f20fa7a288eb0703d995c59940c7c66de57a9b70f82379b70e2031e450fcfd2181326fcd28d8823baaa80df6e0f443559647539fd8907c0ffd9d79c130ed81c9afd9b7e848c9fed38443d5d380e53fbdb8ac8c3d3f06876054f122461107de92fea09c6f6923a188d53afe54a10f60e6e9d5a03d996b5fbc820f8a637116a27ad04b444a0932dd60fbd12671c11e1c0ec73e789879faa3d42c64d20cd1252742a3768c25a901585888ecee1e612d9936b403b0775949a66cdfd99a29b1345baa8d9d5400c91024b0a607363b013ce5de9ae869d3b8d95b0570b3c2d391422d32450cbcfae96652286e96dec1214a9346527980a8192eac1c39a3aaf6f15351da6be764df89772ec0407d06e4415befae7c92580df9bf507497c8f2995160d4e218daacb02944abf83340ce8be1686a960faf90e2d90c55cc6475babc3171a80a363174954955d7101dab16ae8179167e21444b443a9eaaa7c91de36d118c39d389f8dd4469a846c9a262bf7fa18487a79e8de11699e0b8fdf557cb48719d453ba713056109b93a218c89675ac195fb4fb06639b3797144955b3c9327d1aec003d42ecd0ea98abf19ffb4af3561a67e77c35bf15c59c2412da881db02b1bfbcebfac5152bc99bc3f1d15f771001b7029fedb028f8b852bc4407eb83f891c9ca733254fdd1e9edb56919ce9fea21c174072521c18319a54b5d4efbebddf1d8b69b1cbf25f489fcc981372547cf41d008ef0bca1926f934b735e090b3b251eb33a36f82ed9b29cf4cb944188fa0e1e38dd778f7d1c9d987b28d132dfb9731fa4f4b416935be49de30516af3578581f2f13f561c0663361941eab249a4bc123f8d15cd711a956a1bf20fe6eb78aea2373361da0426c79a530c3bb1de0c99722ef1fde39ac2b00a0a8ee7c800a08bc2264f89f4effe627ac2f0531fb554f6d21d74c590a70adfaa390bdfbb3d68e46215cab187d2368d5a71f5ebec081cd3b20c082dbe4cd2faca28773795d6b0c10204b659a939ef29bbe1088243624429927a7eb576dd3a00ea5e01af5d47583b2272c0c161a806521a16ff9b0a722c0cf26b025d5836e2258a4f7d4773ac801e4263bc294f43def7fa8703f3a4197463525887652b0b2a4a2a7cf87f00914871e25039113c7e1618da34064b57a43c463249fb8d05e0f26f4a6d84972e7a9054824145f91295cdbe39a6f920facc659712b46a54ba295bbe6a90154e91b33985a2bcd420ad5c67ec9ad8eb7ac6864db272a516bc94c2839b0a8169a6bf58e1a0c2ada8c883b7bf497a49171268ed15ddd2969384e7ff4bf4aab2ec9ecc6529cf629e2df0f08a77a65afa12aa9b505df8b287ef6cc91493d1caa39076e28ef1ea028f5118de61ae02bb6aefc3343a050292f199f401857b2bead5e6ee2a1f191022f9278016f047791a9d18da7d2a6d27f2e0e51c2f6ea30e8ac49a0604f4c13542e85b68381b9fdcfa0ce4b2d341354852d360245c536b612af71f3e77c9095ae2dbde504b265733dabfe10a20fc7d6d32c21ccc72b8b3444ae663d65922d17f82caa2b865cd88913d291a65899026ea1328439723c198c36b0c3c8d085bfaf8a320fde334b4a4919b44c2b95f6e8ecf73393f7f0d2a40e60b1d406526b022ddc331810b1a5f7c347bd53ed1f105d6a0d30aba477e178889ab2ec55d558deab2630204336962b4db5b663b6902b89e85b31bc6af50fc50accb3fb9b57b663297031378db47896d7fbaf6c600add2c67f936db037986db856eb49cf2db3f7da6d23650e438f1884041b013119e4c2ae5af37cccdfb68660738b58b3c59d1c0248437472aba1f35ca1fb90cd714aa9f635534f49e7c5bba81c2b6b36fdee21ca27e347f793d2ce944edb23c8c9b914be10335e350feb5070394b7a4a15c0ca120283568b7bfc254fe838b137a2147ce7c113a3a4d65499d9e86b87dbcc7f03bbd3a3ab1aa243ece5ba9bcf25f82836cfe473b2d83e7a7201cd0b96a72451e863f6c3ba664a6d073d1f7b5ed990865d978bd3815d06094fc9a2aba5221c22d5ab996389e3721e3af5f05beddc2875e0dfaeb39021ee27a41187cbb45ef40c3e73bc03989f9a30d12c54ba7d2141da8a875493e65776ef35f97debc2286cc4af9b4623eee902f840c52f1b8ad658939aef71f3f72b9ec1de21588bd35484ea44436343ff95ead6ab1d8afb1b2a303df1b71e53c4aea6b2e3e9372be0d1bc99798b0ce3cc10d2a596d565dba82f88ce4cff3b33d5d24e9c0831124bf1ad54b792532983dd6c3a8b7d0">>),
-     % hexstream_to_binary(<<"ebd5ccb0">>)}
+     %% C.2.3 - not supported yet
+     %% C.2.4 - not supported yet
+     %% C.2.5 - not supported yet
+     %% C.2.6 - not supported yet
+     %% C.2.7 - not supported yet
+     %% C.2.8 - not supported yet
     ].
 
 mac_eia2_128_test() ->


### PR DESCRIPTION
Now we can generate MAC in the way 3GPP describes in TS 33.401 B.2.3.

As I wrote in the comments, this does not support the messages not aligned to 8-bit boundary. which I think we don't usually face in real-world signalling.
